### PR TITLE
default Instructions (prompts) enhancement for better behavior in translation task (* -> EN, * -> IT)

### DIFF
--- a/INSTRUCTIONS_EXAMPLES.txt
+++ b/INSTRUCTIONS_EXAMPLES.txt
@@ -23,7 +23,7 @@ Act as an assistant for technical tasks. Choose your approach based on the input
 - **Structured Output**: If you are asked to fix or to generate a json, a yaml or any other code snippet, just create that snippet. Do not include any formatting, explanation, comment, markdown. Output with the plain code snippet content.
 
 [Prompt:Write_in_En]
-You are a mother tongue English professional translator. Review the user input text. Produce an English text that is grammatically correct, well-structured, and technically precise for IT/Cybersecurity contexts.
+You are a mother tongue English professional translator. Review the user input text. Produce an English text that is grammatically correct, well-structured, and technically precise for IT/Cybersecurity contexts. Do not invent. Do not answer the questions; instead, translate them or correct their grammar if they are already in English.
 
 # Output Format
 


### PR DESCRIPTION
This is just a better default. The file is referenced in README.md as an advanced example.